### PR TITLE
Fix issues #2 and #3, so the project works again on latest streamlits

### DIFF
--- a/examples/requirements.txt
+++ b/examples/requirements.txt
@@ -1,1 +1,1 @@
-streamlit-profiler==0.2.4
+streamlit-profiler==0.2.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "streamlit-profiler"
-version = "0.2.4"
+version = "0.2.5"
 description = "Runtime profiler for Streamlit, powered by pyinstrument"
 authors = ["Johannes Rieke <johannes.rieke@gmail.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/jrieke/streamlit-profiler"
 [tool.poetry.dependencies]
 python = "^3.7"
 streamlit = "^1.0.0"
-pyinstrument = "==4.1.1"
+pyinstrument = "==4.2.0"
 
 [tool.poetry.dev-dependencies]
 black = "^21.12b0"

--- a/streamlit_profiler/__init__.py
+++ b/streamlit_profiler/__init__.py
@@ -1,4 +1,4 @@
-import streamlit as st
+import streamlit.components.v1 as components
 from pyinstrument import Profiler as OriginalProfiler
 
 
@@ -79,6 +79,6 @@ class Profiler(OriginalProfiler):
         # html = html.replace(".margins{", ".margins{overflow:scroll;")
 
         # Display modified HTML report in iframe.
-        st.components.v1.html(html, height=600)
+        components.html(html, height=600)
         
         return session


### PR DESCRIPTION
Closes #2, #3.

(update: since these are blocking bugs, meaning the main project cannot be used at all on modern versions of streamlit and python, you can find my fork of this library here, and use it in your projects instead https://pypi.org/project/wfork-streamlit-profiler/)

I basically did the minimal thing that would work.

It seems to me that the "styling stuff" you were worried about still works fine, if that just means the profiler panel looks the same. (Tested with Python 3.10.12)

![image](https://github.com/jrieke/streamlit-profiler/assets/27367056/a8b9e7b5-40cd-44d6-bcd3-4f55dfaf0531)

Let me know if there's anything else I need to investigate wrt this PR.